### PR TITLE
Use temp variable in check for existing parent group

### DIFF
--- a/src/Api/PermissionProviderFactory.php
+++ b/src/Api/PermissionProviderFactory.php
@@ -413,13 +413,15 @@ class PermissionProviderFactory implements PermissionProvider
                 $parentGroupName = $this->parentGroup;
                 $code = $this->codeToCleanCode($parentGroupName);
                 $filter = ['Title' => $parentGroupName, 'Code' => $code];
-                $this->parentGroup = Group::get()->filterAny($filter)->first();
-                if (null === $this->parentGroup) {
+                $candidate = Group::get()->filterAny($filter)->first();
+                if (null === $candidate) {
                     $this->parentGroup = Group::create($filter);
                     $parentGroupStyle = 'created';
                     $this->parentGroup->Title = $parentGroupName;
                     $this->parentGroup->write();
                     $this->showDebugMessage("{$parentGroupStyle} {$parentGroupName}");
+                } else {
+                    $this->parentGroup = $candidate;
                 }
             }
 


### PR DESCRIPTION
Fixes error on dev/build when parent group is not in database: `Uncaught Exception TypeError: "Cannot assign null to property Sunnysideup\PermissionProvider\Api\PermissionProviderFactory::$parentGroup of type SilverStripe\Security\Group|string" at [...]/vendor/sunnysideup/permission_provider/src/Api/PermissionProviderFactory.php line 416 {"exception":"[object] (TypeError(code: 0): Cannot assign null to property Sunnysideup\\PermissionProvider\\Api\\PermissionProviderFactory::$parentGroup of type SilverStripe\\Security\\Group|string at [...]/vendor/sunnysideup/permission_provider/src/Api/PermissionProviderFactory.php:416)"} []`